### PR TITLE
Allow for NAs in weighting vector

### DIFF
--- a/R/util_classify.R
+++ b/R/util_classify.R
@@ -86,17 +86,12 @@ util_classify <- function(x,
 
       x <- .classify(x, weighting)
 
-  }
-
-  if(is.null(real_land)){
-
+  } else {
 
     if (is.null(weighting)){
       breaks <- classInt::classIntervals(raster::getValues(x), n = n, style= style)
       x <-  raster::cut(x, breaks=breaks$brks, include.lowest=T)
-    }
-
-    if (!is.null(weighting)){
+    } else {
       x <- .classify(x, weighting)
     }
 

--- a/R/util_w2cp.R
+++ b/R/util_w2cp.R
@@ -15,6 +15,11 @@
 #' @export
 
 util_w2cp <- function(weighting) {
+  
+  na <- sum(is.na(weighting))
+  na_replace <- (1 - sum(weighting, na.rm = TRUE)) / na
+  weighting[is.na(weighting)] <- na_replace
+  
   w <- weighting
   proportions <- w / sum(w)
   cumulative_proportions <- cumsum(proportions)


### PR DESCRIPTION
NAs in the weighting vector will be automatically replaced by the remaining fraction. 
E.g. util_classify(weighting = c(0.7, NA, NA) becomes util_classify(weighting = c(0.7, 0.15, 0.15). This is convenient for sampling schemes when only one proportion is sampled.