### PR TITLE
fix util_binarize after changes to util_classify

### DIFF
--- a/R/util_binarize.R
+++ b/R/util_binarize.R
@@ -36,7 +36,7 @@ util_binarize.RasterLayer <- function(x, breaks) {
         util_classify(
           x,
           weighting = c(1 - breaks[i], breaks[i]),
-          c("Matrix", "Habitat")
+          level_names = c("Matrix", "Habitat")
         )
       )
     }
@@ -46,7 +46,7 @@ util_binarize.RasterLayer <- function(x, breaks) {
     r <- util_classify(
       x,
       weighting = c(1 - breaks, breaks),
-      c("Matrix", "Habitat")
+      level_names = c("Matrix", "Habitat")
     )
   }
 


### PR DESCRIPTION
The changes to util_classify (option to use `n` or `weighting` mean that this function throws the warning `If n AND weighting are used, util_classify will fallback to weighting as classification method.` because it thinks that n has been supplied due to the unnamed `level_names` argument.