### PR TITLE
Help pkgdown auto-detect GitHub repo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ LazyData: true
 ByteCompile: true
 Depends:
     R (>= 3.1.0)
-URL: https://ropensci.github.io/landscapetools/
+URL: https://ropensci.github.io/landscapetools/, https://github.com/ropensci/landscapetools
 BugReports: https://github.com/ropensci/landscapetools/issues
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.1.1


### PR DESCRIPTION
This will add a GitHub icon in the top navbar in the pkgdown website to go to the GitHub repo.