### PR TITLE
Bugfix#26

### DIFF
--- a/R/util_classify.R
+++ b/R/util_classify.R
@@ -136,12 +136,9 @@ util_classify.RasterLayer <- function(x,
   }
 
   # Classify the matrix based on the boundary values ----
-  raster::values(x) <- findInterval(raster::values(x),
-                                    boundary_values,
-                                    rightmost.closed = TRUE)
-
-  # first class should be 1
-  x <- x + 1
+  raster::values(x) <-  base::cut(raster::values(x),
+                                  breaks = c(0, boundary_values),
+                                  include.lowest = TRUE)
 
   return(x)
 

--- a/R/util_classify.R
+++ b/R/util_classify.R
@@ -138,7 +138,7 @@ util_classify.RasterLayer <- function(x,
   # Classify the matrix based on the boundary values ----
   raster::values(x) <-  base::cut(raster::values(x),
                                   breaks = c(0, boundary_values),
-                                  include.lowest = TRUE)
+                                  include.lowest = TRUE, labels = FALSE)
 
   return(x)
 


### PR DESCRIPTION
This aims to fix #26. I changed the following part in `util_classify.R` 
## New:
```
.classify <- function(x, weighting){
#[...]
  # Classify the matrix based on the boundary values ----
  raster::values(x) <-  base::cut(raster::values(x),
                                  breaks = c(0, boundary_values),
                                  include.lowest = TRUE, labels = FALSE)

#[...]
}
```
## Old
```
.classify <- function(x, weighting){
#[...]
# Classify the matrix based on the boundary values ----
  raster::values(x) <- findInterval(raster::values(x),
                                    boundary_values,
                                    rightmost.closed = TRUE)

  # first class should be 1
  x <- x + 1

#[...]
}
```

Does anyone see something that could go wrong with the new version?

Besides, we should write a test that covers issue #26 before merging.