### PR TITLE
Adapting functions to terra: `show_landscape()`, `util_rescale()`, `util_tibble2raster()`, and `util_raster2tibble()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,6 +42,7 @@ RoxygenNote: 7.1.0
 Imports: 
     ggplot2,
     raster,
+    terra,
     tibble,
     Rcpp
 Suggests: 

--- a/R/show_landscape.R
+++ b/R/show_landscape.R
@@ -91,6 +91,49 @@ show_landscape.RasterLayer <- function(x,
 
 #' @name show_landscape
 #' @export
+show_landscape.SpatRaster <- function(x,
+                                      xlab = "Easting",
+                                      ylab = "Northing",
+                                      discrete = FALSE,
+                                      ...) {
+  # derive ratio for plot, cells should be a square and axis equal in length
+  if (terra::ncol(x) == terra::nrow(x)) {
+    ratio <- 1
+  } else {
+    ratio <- terra::nrow(x) / terra::ncol(x)
+  }
+  if (isTRUE(discrete)) {
+    # get rasterlabels
+    legend_labels <- tryCatch({
+      terra::levels(x)[!is.na(terra::levels(x))]
+    },
+    error = function(e) {
+      x <- raster::as.factor(x) # error
+      levels <- terra::unique(x)
+      levels(x) <- levels # error
+    })
+
+    xyz  <- terra::as.data.frame(x, xy = TRUE)
+
+    ggplot2::ggplot(xyz) +
+      ggplot2::geom_tile(ggplot2::aes(x, y, fill = factor(xyz[, 3]))) +
+      ggplot2::labs(x = xlab,
+                    y = ylab)  +
+      theme_nlm_discrete(..., legend_labels = legend_labels, ratio = ratio)
+
+  } else {
+    xyz  <- raster::as.data.frame(x, xy = TRUE)
+
+    ggplot2::ggplot(xyz) +
+      ggplot2::geom_tile(ggplot2::aes(x, y, fill = xyz[, 3])) +
+      ggplot2::labs(x = xlab,
+                    y = ylab) +
+      theme_nlm(..., ratio = ratio)
+  }
+}
+
+#' @name show_landscape
+#' @export
 show_landscape.list <- function(x,
                                 xlab = "Easting",
                                 ylab = "Northing",

--- a/R/util_raster2tibble.R
+++ b/R/util_raster2tibble.R
@@ -32,16 +32,16 @@ util_raster2tibble <- function(x, format = "long") {
 
   if (format == "long"){
   # Create empty tibble with the same dimension as the raster ----
-  grd <- tibble::new_tibble(expand.grid(x = seq(1, raster::ncol(x)),
-                                        y = seq(raster::nrow(x), 1)),
-                            nrow = raster::ncell(x))
+  grd <- tibble::new_tibble(expand.grid(x = seq(1, terra::ncol(x)),
+                                        y = seq(terra::nrow(x), 1)),
+                            nrow = terra::ncell(x))
 
   # Fill with raster values ----
-  grd$z <- raster::values(x)
+  grd$z <- terra::values(x)
   }
 
   if (format == "wide"){
-    grd <- tibble::as_tibble(raster::as.matrix(x), .name_repair = "universal")
+    grd <- tibble::as_tibble(terra::as.matrix(x), .name_repair = "universal")
     colnames(grd) <- seq_len(ncol(grd))
   }
 

--- a/R/util_rescale.R
+++ b/R/util_rescale.R
@@ -29,4 +29,12 @@ util_rescale <- function(x) {
   return(rescaled_NLM)
 }
 
+#' @name util_rescale
+#' @export
+util_rescale.SpatRaster <- function(x) {
+    rescaled_NLM <-
+        (x - terra::global(x, "min")) /
+        (terra::global(x, "max") - terra::global(x, "min"))
 
+    return(rescaled_NLM)
+}

--- a/R/util_tibble2raster.R
+++ b/R/util_tibble2raster.R
@@ -36,3 +36,16 @@ util_tibble2raster <- function(x) {
 
   return(r)
 }
+
+#' @name util_tibble2raster
+#' @export
+# for terra, not yet exported
+# (not sure how to include use methods for that)
+util_tibble2raster_terra <- function(x) {
+
+    # Create raster with values from tibble ----
+    r <- terra::rast(matrix(x$z, max(x$y), max(x$x), byrow = TRUE))
+    terra::ext(r) <- c(0, max(x$x), 0, max(x$y))
+
+    return(r)
+}


### PR DESCRIPTION
Hi,

I tried starting to adapt a few functions to use with `SpatRaster` objects from the `terra` package, as raised in #33, but I had issues using the methods of the same functions for different classes of data. So far I tried these functions: `show_landscape()`, `util_rescale()`, `util_tibble2raster()`, and `util_raster2tibble()`.

The only one that works is `util_rescale()`, since the functions from `terra` also work on `raster` objects. Yet, there is a minor difference in the name of the 3rd column.

Here a script to test them.
```r
library(landscapetools)
library(terra)
library(dplyr)

# example dataset
x <- gradient_landscape
y <- gradient_landscape %>%
    terra::rast()

# show landscape
show_landscape(x)
show_landscape(y) # does not work

# util rescale
util_rescale(x)
util_rescale(y) # does not work

# util_raster2tibble
util_raster2tibble(x)
util_raster2tibble(y) # that works, but the 3rd column is called z[,"layer"] instead of z

# util_tibble2raster
tib <- util_raster2tibble(x)
util_tibble2raster(tib)
util_tibble2raster_terra(tib) # not exported

```